### PR TITLE
quick contact style - done until more content is added

### DIFF
--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -3,25 +3,23 @@ import "../styles/Contact.css";
 
 const Contact = () => {
   return (
-    <div>
-      <div style={{ left: 280, paddingLeft: 280, zIndex: 1 }}>
-        <a href="https://github.com/Djimovanberlo" target="_blank">
-          <img
-            src={require("../img/icons/Github.png")}
-            style={{ height: 25, width: 25 }}
-          />
-        </a>
-        <a href="https://www.linkedin.com/in/djimo-van-berlo/" target="_blank">
-          <img
-            src={require("../img/icons/LinkedIn.png")}
-            style={{ height: 25, width: 25 }}
-          />
-        </a>
-        <div>+31 (0) 6 34 85 85 54</div>
-        <div>djimovanberlo@gmail.com</div>
-        <div>Rampe du Val 9b2</div>
-        <div>1348 Louvain-La-Neuve</div>
-      </div>
+    <div className="content">
+      <a href="https://github.com/Djimovanberlo" target="_blank">
+        <img
+          src={require("../img/icons/Github.png")}
+          style={{ height: 30, width: 30, padding: 5 }}
+        />
+      </a>
+      <a href="https://www.linkedin.com/in/djimo-van-berlo/" target="_blank">
+        <img
+          src={require("../img/icons/LinkedIn.png")}
+          style={{ height: 30, width: 30, padding: 5 }}
+        />
+      </a>
+      <div>+31 (0) 6 34 85 85 54</div>
+      <div>djimovanberlo@gmail.com</div>
+      <div>Rampe du Val 9b2</div>
+      <div>1348 Louvain-La-Neuve</div>
     </div>
   );
 };

--- a/src/styles/Contact.css
+++ b/src/styles/Contact.css
@@ -1,25 +1,9 @@
-/* .picture {
-  position: relative;
-  top: 10px;
-  left: -430px;
-  z-index: 1;
-} */
-/* 
-.name {
-  text-decoration: none;
-  font-size: 50px;
-  color: #f1f1f1;
+.content {
+  position: absolute;
+  font-size: 20px;
+  letter-spacing: 2px;
+  text-align: left;
+  left: 280px;
+  top: 200px;
+  padding: 40px;
 }
-
-.title {
-  text-decoration: none;
-  font-size: 25px;
-  color: #f1f1f1;
-}
-
-.img {
-  border-radius: 50%;
-  height: 200;
-  width: 200;
-  padding: 20px 20px 20px 20px;
-} */


### PR DESCRIPTION
- Contact page now has styling
- warning: copied .content{} properties to Contact.css, but it uses the exact same properties as About.css. So when refactoring, these can be combined into one css file.